### PR TITLE
Command line args

### DIFF
--- a/holoscribe/Cargo.lock
+++ b/holoscribe/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +99,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "obj",
+ "regex",
  "svg",
  "thiserror",
 ]
@@ -127,6 +137,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "obj"
@@ -187,6 +203,23 @@ checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustix"

--- a/holoscribe/Cargo.toml
+++ b/holoscribe/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.1.6", features = ["derive"] }
 obj = "0.10.2"
+regex = "1.7.1"
 svg = "0.13.0"
 thiserror = "1.0.38"
+

--- a/holoscribe/Cargo.toml
+++ b/holoscribe/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.1.6", features = ["derive"] }
 obj = "0.10.2"
-regex = "1.7.1"
+regex = "1"
 svg = "0.13.0"
 thiserror = "1.0.38"
 

--- a/holoscribe/src/cli.rs
+++ b/holoscribe/src/cli.rs
@@ -28,7 +28,7 @@ pub struct Args {
 
     /// The size of the image you which to create. Requires the format: width[xheight](mm|cm|m)
     #[arg(short, long, value_parser=parse_size)]
-    pub size: Size,
+    pub canvas_size: CanvasSize,
 
     /// The density of lines etched per mm. Defaults to 1.
     #[arg(long, default_value_t = 1)]
@@ -37,12 +37,12 @@ pub struct Args {
 
 /// Represents a size in millimeters
 #[derive(Debug, Clone, PartialEq)]
-pub struct Size {
+pub struct CanvasSize {
     pub width: usize,
     pub height: usize,
 }
 
-fn parse_size(arg: &str) -> Result<Size, CliError> {
+fn parse_size(arg: &str) -> Result<CanvasSize, CliError> {
     let re = Regex::new(r"^(\d+|\d+x\d+)(mm|cm|m)$").unwrap();
     if let Some(cap) = re.captures(arg) {
         let unit = cap.get(2).expect("Regex requires a unit").as_str();
@@ -71,7 +71,7 @@ fn parse_size(arg: &str) -> Result<Size, CliError> {
         };
 
         // Normalize size to millimeters
-        Ok(Size {
+        Ok(CanvasSize {
             width: width * factor,
             height: height * factor,
         })
@@ -82,40 +82,37 @@ fn parse_size(arg: &str) -> Result<Size, CliError> {
 
 #[cfg(test)]
 mod tests {
-    use std::num::{
-        IntErrorKind::{self, PosOverflow},
-        ParseIntError,
-    };
+    use std::num::IntErrorKind;
 
-    use crate::cli::{parse_size, CliError, Size};
+    use crate::cli::{parse_size, CanvasSize, CliError};
 
     #[test]
     fn test_parse_size() {
         // Check that sizes are parsed and units are applied
         assert_eq!(
             parse_size("10x10mm"),
-            Ok(Size {
+            Ok(CanvasSize {
                 width: 10,
                 height: 10
             })
         );
         assert_eq!(
             parse_size("10x50cm"),
-            Ok(Size {
+            Ok(CanvasSize {
                 width: 100,
                 height: 500
             })
         );
         assert_eq!(
             parse_size("10cm"),
-            Ok(Size {
+            Ok(CanvasSize {
                 width: 100,
                 height: 100
             })
         );
         assert_eq!(
             parse_size("2x1m"),
-            Ok(Size {
+            Ok(CanvasSize {
                 width: 2000,
                 height: 1000
             })

--- a/holoscribe/src/cli.rs
+++ b/holoscribe/src/cli.rs
@@ -1,1 +1,58 @@
+use std::num::ParseIntError;
 
+use clap::Parser;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum CliError {
+    #[error("Invalid output size specification")]
+    InvalidSize(ParseIntError),
+}
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
+/// A command line utility that take an .obj model and produce a .svg representations of lines to etch
+/// to create a holographic image of that model
+pub struct Args {
+    /// Input file. Expects a .obj file
+    #[arg(short, long)]
+    pub input: String,
+
+    /// Output file. Expects a .svg file
+    #[arg(short, long)]
+    pub output: String,
+
+    /// The size in (TODO units) of the image you which to create. Takes the format: width[xheight]
+    #[arg(short, long, value_parser=parse_size)]
+    pub size: Size,
+
+    /// The density of lines etched per (TODO unit). Defaults to (TODO default)
+    #[arg(long, default_value_t = 1)]
+    pub stroke_density: usize,
+}
+
+#[derive(Clone)]
+pub struct Size {
+    pub width: usize,
+    pub height: usize,
+}
+
+fn parse_size(arg: &str) -> Result<Size, CliError> {
+    if let Some((width, height)) = arg.split_once('x') {
+        Ok(Size {
+            width: width
+                .parse::<usize>()
+                .map_err(|e| CliError::InvalidSize(e))?,
+            height: height
+                .parse::<usize>()
+                .map_err(|e| CliError::InvalidSize(e))?,
+        })
+    } else {
+        let width = arg.parse::<usize>().map_err(|e| CliError::InvalidSize(e))?;
+        Ok(Size {
+            width,
+            height: width,
+        })
+    }
+}

--- a/holoscribe/src/cli.rs
+++ b/holoscribe/src/cli.rs
@@ -1,12 +1,15 @@
 use std::num::ParseIntError;
 
 use clap::Parser;
+use regex::Regex;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum CliError {
-    #[error("Invalid output size specification")]
-    InvalidSize(ParseIntError),
+    #[error("Invalid int specification for size")]
+    InvalidSizeInt(ParseIntError),
+    #[error("Invalid size specification")]
+    InvalidSize,
 }
 
 #[derive(Parser)]
@@ -23,36 +26,117 @@ pub struct Args {
     #[arg(short, long)]
     pub output: String,
 
-    /// The size in (TODO units) of the image you which to create. Takes the format: width[xheight]
+    /// The size of the image you which to create. Requires the format: width[xheight](mm|cm|m)
     #[arg(short, long, value_parser=parse_size)]
     pub size: Size,
 
-    /// The density of lines etched per (TODO unit). Defaults to (TODO default)
+    /// The density of lines etched per mm. Defaults to 1.
     #[arg(long, default_value_t = 1)]
     pub stroke_density: usize,
 }
 
-#[derive(Clone)]
+/// Represents a size in millimeters
+#[derive(Debug, Clone, PartialEq)]
 pub struct Size {
     pub width: usize,
     pub height: usize,
 }
 
 fn parse_size(arg: &str) -> Result<Size, CliError> {
-    if let Some((width, height)) = arg.split_once('x') {
+    let re = Regex::new(r"^(\d+)x?(\d*)(mm|cm|m)$").unwrap();
+    if let Some(cap) = re.captures(arg) {
+        // We always expect to match the first group (width)
+        let width_str = cap.get(1).unwrap().as_str();
+        let width = width_str
+            .parse::<usize>()
+            .map_err(|e| CliError::InvalidSizeInt(e))?;
+
+        // The second group (height) is optional, without it just use width
+        let height = if let Some(height) = cap.get(2) {
+            let height_str = height.as_str();
+            if height_str.len() > 0 {
+                height
+                    .as_str()
+                    .parse::<usize>()
+                    .map_err(|e| CliError::InvalidSizeInt(e))?
+            } else {
+                width
+            }
+        } else {
+            width
+        };
+
+        // We always expect to have a unit
+        let unit = cap.get(3).unwrap().as_str();
+
+        // Normalize to mm
+        let factor = match unit {
+            "mm" => 1,
+            "cm" => 10,
+            "m" => 1000,
+            _ => panic!("Regex should not have allowed any other unit string"),
+        };
         Ok(Size {
-            width: width
-                .parse::<usize>()
-                .map_err(|e| CliError::InvalidSize(e))?,
-            height: height
-                .parse::<usize>()
-                .map_err(|e| CliError::InvalidSize(e))?,
+            width: width * factor,
+            height: height * factor,
         })
     } else {
-        let width = arg.parse::<usize>().map_err(|e| CliError::InvalidSize(e))?;
-        Ok(Size {
-            width,
-            height: width,
-        })
+        Err(CliError::InvalidSize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::{
+        IntErrorKind::{self, PosOverflow},
+        ParseIntError,
+    };
+
+    use crate::cli::{parse_size, CliError, Size};
+
+    #[test]
+    fn test_parse_size() {
+        // Check that sizes are parsed and units are applied
+        assert_eq!(
+            parse_size("10x10mm"),
+            Ok(Size {
+                width: 10,
+                height: 10
+            })
+        );
+        assert_eq!(
+            parse_size("10x50cm"),
+            Ok(Size {
+                width: 100,
+                height: 500
+            })
+        );
+        assert_eq!(
+            parse_size("10cm"),
+            Ok(Size {
+                width: 100,
+                height: 100
+            })
+        );
+        assert_eq!(
+            parse_size("2x1m"),
+            Ok(Size {
+                width: 2000,
+                height: 1000
+            })
+        );
+
+        // Test invalid size specifications
+        assert_eq!(parse_size("10x"), Err(CliError::InvalidSize));
+        assert_eq!(parse_size("10x10ft"), Err(CliError::InvalidSize));
+        assert_eq!(parse_size("-10x10mm"), Err(CliError::InvalidSize));
+
+        // check usize::MAX + 1
+        if let CliError::InvalidSizeInt(e) = parse_size("18446744073709552000mm").unwrap_err() {
+            let kind = e.kind();
+            assert_eq!(kind, &IntErrorKind::PosOverflow);
+        } else {
+            panic!("Unexpected error type")
+        }
     }
 }

--- a/holoscribe/src/cli.rs
+++ b/holoscribe/src/cli.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 pub enum CliError {
     #[error("Invalid int specification for size")]
     InvalidSizeInt(ParseIntError),
-    #[error("Invalid size specification")]
+    #[error("Invalid size specification, please use the format: width[xheight](mm|cm|m)")]
     InvalidSize,
 }
 

--- a/holoscribe/src/cli.rs
+++ b/holoscribe/src/cli.rs
@@ -120,6 +120,7 @@ mod tests {
 
         // Test invalid size specifications
         assert_eq!(parse_size("10x"), Err(CliError::InvalidSize));
+        assert_eq!(parse_size("10"), Err(CliError::InvalidSize));
         assert_eq!(parse_size("312xmm"), Err(CliError::InvalidSize));
         assert_eq!(parse_size("10x10ft"), Err(CliError::InvalidSize));
         assert_eq!(parse_size("-10x10mm"), Err(CliError::InvalidSize));

--- a/holoscribe/src/main.rs
+++ b/holoscribe/src/main.rs
@@ -9,7 +9,6 @@ use obj::Obj;
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // TODO: use Clap if this gets unwieldy in the future
     let args = Args::parse();
     let user_defined_model = obj_from_file(args.input).unwrap();
     let verts = user_defined_model.data.position;

--- a/holoscribe/src/main.rs
+++ b/holoscribe/src/main.rs
@@ -3,16 +3,15 @@ mod scriber;
 //cli accepts obj file and svg location (and optional parameters)
 mod cli;
 
+use clap::Parser;
+use cli::Args;
 use obj::Obj;
-use std::env;
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // TODO: use Clap if this gets unwieldy in the future
-    let args: Vec<String> = env::args().collect();
-    let input_model_file_path = args[1].clone();
-
-    let user_defined_model = obj_from_file(input_model_file_path).unwrap();
+    let args = Args::parse();
+    let user_defined_model = obj_from_file(args.input).unwrap();
     let verts = user_defined_model.data.position;
 
     let arc_strat = scriber::DebugScriber {
@@ -24,7 +23,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let scriber = scriber::Scriber::new(arc_strat);
     let svg = scriber.scribe(&verts);
 
-    svg::save("test.svg", &svg).expect("failed to save");
+    svg::save(args.output, &svg).expect("failed to save");
     Ok(())
 }
 


### PR DESCRIPTION
Use clap to add support input file, output file, output size, optional stroke density.

Help message:
```
A command line utility that take an .obj model and produce a .svg representations of lines to etch to create a holographic image of that model

Usage: holoscribe [OPTIONS] --input <INPUT> --output <OUTPUT> --size <SIZE>

Options:
  -i, --input <INPUT>
          Input file. Expects a .obj file
  -o, --output <OUTPUT>
          Output file. Expects a .svg file
  -s, --size <SIZE>
          The size of the image you which to create. Requires the format: width[xheight](mm|cm|m)
      --stroke-density <STROKE_DENSITY>
          The density of lines etched per mm. Defaults to 1 [default: 1]
  -h, --help
          Print help
  -V, --version
          Print version
```

Invalid output size specification:
```
$ cargo run -- -i cube.obj -o test3.svg -s 10
   Compiling holoscribe v0.1.0 (/home/sara/develop/recurse/holographit/holoscribe)
    Finished dev [unoptimized + debuginfo] target(s) in 1.04s
     Running `target/debug/holoscribe -i cube.obj -o test3.svg -s 10`
error: invalid value '10' for '--size <SIZE>': Invalid size specification, please use the format: width[xheight](mm|cm|m)

For more information, try '--help'.
```