### PR TITLE
Rework size scaling for hologram scribing

### DIFF
--- a/holocli/src/main.rs
+++ b/holocli/src/main.rs
@@ -5,17 +5,20 @@ mod cli;
 
 use std::error::Error;
 
-use holoscribe::{model::ObjInterpolator, scriber};
 use clap::Parser;
 use cli::Args;
+use holoscribe::{model::ObjInterpolator, scriber};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
     let user_defined_model = ObjInterpolator::from_file(args.input).unwrap();
     let interpolated_points = user_defined_model.interpolate_edges(args.stroke_density);
 
-    let circle_strat = scriber::CircleScriber {};
-    let scriber = scriber::Scriber::new(circle_strat, (args.canvas_size.width, args.canvas_size.height));
+    let circle_strat = scriber::CircleScriber::new();
+    let scriber = scriber::Scriber::new(
+        circle_strat,
+        (args.canvas_size.width, args.canvas_size.height),
+    );
 
     let svg = scriber.scribe(&interpolated_points);
 

--- a/holoscribe/src/lib.rs
+++ b/holoscribe/src/lib.rs
@@ -22,7 +22,7 @@ mod tests {
         let model =
             ObjInterpolator::from_file("tests/icosahedron.obj".to_string()).expect("invalid model");
         let interpolated_points = model.interpolate_edges(100);
-        let circle_strat = scriber::CircleScriber {};
+        let circle_strat = scriber::CircleScriber::new();
         let scriber = scriber::Scriber::new(circle_strat, (100, 100));
         b.iter(|| scriber.scribe(&interpolated_points));
     }


### PR DESCRIPTION
The main things this PR addresses are:
1. Set the `width` and `height` of the containing SVG document based on the canvas size
2. Create an inner `viewbox` for compute the `extent` for it based on the bounds of the point set plus some margin
3. Change the margin to be proportional rather than absolute 

With all of these changes, we can use the x and y point locations directly, and trust the outer SVG to scale the image.

For example, with a `canvas_size=10x10cm` and a margin of `0.25` (or 25%), we get SVGs that look like this:
```
<svg height="100" width="100" xmlns="http://www.w3.org/2000/svg">
<svg viewBox="-1.850651 -1.850651 2.701302 2.701302" xmlns="http://www.w3.org/2000/svg">
<circle cx="-0.525731" cy="0.850651" fill="none" r="0" stroke="black" stroke-width="0.005"/>
<circle cx="-0.42058483" cy="0.850651" fill="none" r="0" stroke="black" stroke-width="0.005"/>
<circle cx="-0.31543863" cy="0.850651" fill="none" r="0" stroke="black" stroke-width="0.005"/>
...
</svg>
</svg>
```
![test4](https://user-images.githubusercontent.com/3758853/223586356-d769e0f6-d4f4-40e3-9d23-9fc8bf22eb02.svg)

Because the extent is computed based on the point set, the object is centered. With a bit of a margin, all the circles fit in the image. 